### PR TITLE
Update 07/11 (#2)

### DIFF
--- a/common/Changes.md
+++ b/common/Changes.md
@@ -1,5 +1,10 @@
 # Changes
 
+## Jul 8, 2023
+
+* Introduced a default of 20 for sync failures retries in argo applications (global override via global.options.applicationRetryLimit
+  and per-app override via .syncPolicy)
+
 ## May 22, 2023
 
 * Upgraded ESO to 0.8.2

--- a/common/acm/templates/policies/application-policies.yaml
+++ b/common/acm/templates/policies/application-policies.yaml
@@ -95,6 +95,8 @@ spec:
                     automated:
                       prune: false
                       selfHeal: true
+                    retry:
+                      limit: {{ default 20 $.Values.global.options.applicationRetryLimit }}
                   ignoreDifferences:
                   - group: apps
                     kind: Deployment

--- a/common/clustergroup/templates/plumbing/applications.yaml
+++ b/common/clustergroup/templates/plumbing/applications.yaml
@@ -35,6 +35,8 @@ spec:
       {{- else }}
       syncPolicy:
         automated: {}
+        retry:
+          limit: {{ default 20 $.Values.global.options.applicationRetryLimit }}
       {{- end }}
       {{- if .ignoreDifferences }}
       ignoreDifferences: {{ .ignoreDifferences | toPrettyJson }}
@@ -239,6 +241,8 @@ spec:
   {{- else }}
   syncPolicy:
     automated: {}
+    retry:
+      limit: {{ default 20 $.Values.global.applicationRetryLimit }}
     #  selfHeal: true
   {{- end }}
 ---

--- a/common/clustergroup/values.schema.json
+++ b/common/clustergroup/values.schema.json
@@ -192,6 +192,10 @@
           "type": "string",
           "deprecated": true,
           "description": "This is used to approval strategy for the subscriptions of OpenShift Operators being installed. You can choose Automatic or Manual updates. NOTE: This setting is now available in the subcriptions description in the values file."
+        },
+        "applicationRetryLimit": {
+          "type": "integer",
+          "description": "Number of failed sync attempt retries; unlimited number of attempts if less than 0"
         }
       },
       "required": [

--- a/common/clustergroup/values.yaml
+++ b/common/clustergroup/values.yaml
@@ -5,6 +5,7 @@ global:
     useCSV: True
     syncPolicy: Automatic
     installPlanApproval: Automatic
+    applicationRetryLimit: 20
 
 enabled: "all"
 

--- a/common/tests/acm-industrial-edge-hub.expected.yaml
+++ b/common/tests/acm-industrial-edge-hub.expected.yaml
@@ -246,6 +246,8 @@ spec:
                     automated:
                       prune: false
                       selfHeal: true
+                    retry:
+                      limit: 20
                   ignoreDifferences:
                   - group: apps
                     kind: Deployment

--- a/common/tests/acm-medical-diagnosis-hub.expected.yaml
+++ b/common/tests/acm-medical-diagnosis-hub.expected.yaml
@@ -237,6 +237,8 @@ spec:
                     automated:
                       prune: false
                       selfHeal: true
+                    retry:
+                      limit: 20
                   ignoreDifferences:
                   - group: apps
                     kind: Deployment

--- a/common/tests/acm-normal.expected.yaml
+++ b/common/tests/acm-normal.expected.yaml
@@ -655,6 +655,8 @@ spec:
                     automated:
                       prune: false
                       selfHeal: true
+                    retry:
+                      limit: 20
                   ignoreDifferences:
                   - group: apps
                     kind: Deployment
@@ -747,6 +749,8 @@ spec:
                     automated:
                       prune: false
                       selfHeal: true
+                    retry:
+                      limit: 20
                   ignoreDifferences:
                   - group: apps
                     kind: Deployment

--- a/common/tests/clustergroup-industrial-edge-factory.expected.yaml
+++ b/common/tests/clustergroup-industrial-edge-factory.expected.yaml
@@ -145,6 +145,7 @@ data:
       localClusterDomain: apps.region.example.com
       namespace: pattern-namespace
       options:
+        applicationRetryLimit: 20
         installPlanApproval: Automatic
         syncPolicy: Manual
         useCSV: true
@@ -382,6 +383,8 @@ spec:
 }
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/applications.yaml
@@ -428,6 +431,8 @@ spec:
           value: apps.region.example.com
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/argocd.yaml

--- a/common/tests/clustergroup-industrial-edge-hub.expected.yaml
+++ b/common/tests/clustergroup-industrial-edge-hub.expected.yaml
@@ -306,6 +306,7 @@ data:
       localClusterDomain: apps.region.example.com
       namespace: pattern-namespace
       options:
+        applicationRetryLimit: 20
         installPlanApproval: Automatic
         syncPolicy: Manual
         useCSV: true
@@ -713,6 +714,8 @@ spec:
 ]
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/applications.yaml
@@ -759,6 +762,8 @@ spec:
           value: apps.region.example.com
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/applications.yaml
@@ -805,6 +810,8 @@ spec:
           value: apps.region.example.com
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/applications.yaml
@@ -881,6 +888,8 @@ spec:
 ]
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/applications.yaml
@@ -927,6 +936,8 @@ spec:
           value: apps.region.example.com
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/applications.yaml
@@ -973,6 +984,8 @@ spec:
           value: apps.region.example.com
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/applications.yaml
@@ -997,6 +1010,8 @@ spec:
 }
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/applications.yaml
@@ -1061,6 +1076,8 @@ spec:
           value: "1.10.3-ubi"
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/argocd.yaml

--- a/common/tests/clustergroup-medical-diagnosis-hub.expected.yaml
+++ b/common/tests/clustergroup-medical-diagnosis-hub.expected.yaml
@@ -293,6 +293,7 @@ data:
       localClusterDomain: apps.region.example.com
       namespace: pattern-namespace
       options:
+        applicationRetryLimit: 20
         installPlanApproval: Automatic
         syncPolicy: Manual
         useCSV: true
@@ -649,6 +650,8 @@ spec:
           value: apps.region.example.com
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/applications.yaml
@@ -695,6 +698,8 @@ spec:
           value: apps.region.example.com
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/applications.yaml
@@ -741,6 +746,8 @@ spec:
           value: apps.region.example.com
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/applications.yaml
@@ -787,6 +794,8 @@ spec:
           value: apps.region.example.com
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/applications.yaml
@@ -833,6 +842,8 @@ spec:
           value: apps.region.example.com
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/applications.yaml
@@ -879,6 +890,8 @@ spec:
           value: apps.region.example.com
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/applications.yaml
@@ -925,6 +938,8 @@ spec:
           value: apps.region.example.com
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/applications.yaml
@@ -989,6 +1004,8 @@ spec:
           value: "1.10.3-ubi"
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/applications.yaml
@@ -1035,6 +1052,8 @@ spec:
           value: apps.region.example.com
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/applications.yaml
@@ -1081,6 +1100,8 @@ spec:
           value: apps.region.example.com
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/applications.yaml
@@ -1136,6 +1157,8 @@ spec:
 ]
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/applications.yaml
@@ -1191,6 +1214,8 @@ spec:
 ]
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/applications.yaml
@@ -1237,6 +1262,8 @@ spec:
           value: apps.region.example.com
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/argocd.yaml

--- a/common/tests/clustergroup-naked.expected.yaml
+++ b/common/tests/clustergroup-naked.expected.yaml
@@ -66,6 +66,7 @@ data:
     enabled: all
     global:
       options:
+        applicationRetryLimit: 20
         installPlanApproval: Automatic
         syncPolicy: Automatic
         useCSV: true

--- a/common/tests/clustergroup-normal.expected.yaml
+++ b/common/tests/clustergroup-normal.expected.yaml
@@ -198,6 +198,7 @@ data:
       multiClusterTarget: all
       namespace: pattern-namespace
       options:
+        applicationRetryLimit: 20
         installPlanApproval: Automatic
         syncPolicy: Automatic
         useCSV: false
@@ -563,6 +564,8 @@ spec:
 ]
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/applications.yaml
@@ -609,6 +612,8 @@ spec:
           value: apps.region.example.com
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/hosted-sites.yaml

--- a/common/values-global.yaml
+++ b/common/values-global.yaml
@@ -3,6 +3,7 @@ global:
     useCSV: True
     syncPolicy: Manual
     installPlanApproval: Automatic
+    applicationRetryLimit: 20
 
   git:
     hostname: github.com

--- a/tests/common-acm-industrial-edge-hub.expected.yaml
+++ b/tests/common-acm-industrial-edge-hub.expected.yaml
@@ -246,6 +246,8 @@ spec:
                     automated:
                       prune: false
                       selfHeal: true
+                    retry:
+                      limit: 20
                   ignoreDifferences:
                   - group: apps
                     kind: Deployment

--- a/tests/common-acm-medical-diagnosis-hub.expected.yaml
+++ b/tests/common-acm-medical-diagnosis-hub.expected.yaml
@@ -237,6 +237,8 @@ spec:
                     automated:
                       prune: false
                       selfHeal: true
+                    retry:
+                      limit: 20
                   ignoreDifferences:
                   - group: apps
                     kind: Deployment

--- a/tests/common-acm-normal.expected.yaml
+++ b/tests/common-acm-normal.expected.yaml
@@ -655,6 +655,8 @@ spec:
                     automated:
                       prune: false
                       selfHeal: true
+                    retry:
+                      limit: 20
                   ignoreDifferences:
                   - group: apps
                     kind: Deployment
@@ -747,6 +749,8 @@ spec:
                     automated:
                       prune: false
                       selfHeal: true
+                    retry:
+                      limit: 20
                   ignoreDifferences:
                   - group: apps
                     kind: Deployment

--- a/tests/common-clustergroup-industrial-edge-factory.expected.yaml
+++ b/tests/common-clustergroup-industrial-edge-factory.expected.yaml
@@ -140,6 +140,7 @@ data:
       localClusterDomain: apps.region.example.com
       namespace: pattern-namespace
       options:
+        applicationRetryLimit: 20
         installPlanApproval: Automatic
         syncPolicy: Automatic
         useCSV: false
@@ -377,6 +378,8 @@ spec:
 }
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/applications.yaml
@@ -423,6 +426,8 @@ spec:
           value: apps.region.example.com
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/argocd.yaml

--- a/tests/common-clustergroup-industrial-edge-hub.expected.yaml
+++ b/tests/common-clustergroup-industrial-edge-hub.expected.yaml
@@ -301,6 +301,7 @@ data:
       localClusterDomain: apps.region.example.com
       namespace: pattern-namespace
       options:
+        applicationRetryLimit: 20
         installPlanApproval: Automatic
         syncPolicy: Automatic
         useCSV: false
@@ -708,6 +709,8 @@ spec:
 ]
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/applications.yaml
@@ -754,6 +757,8 @@ spec:
           value: apps.region.example.com
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/applications.yaml
@@ -800,6 +805,8 @@ spec:
           value: apps.region.example.com
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/applications.yaml
@@ -876,6 +883,8 @@ spec:
 ]
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/applications.yaml
@@ -922,6 +931,8 @@ spec:
           value: apps.region.example.com
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/applications.yaml
@@ -968,6 +979,8 @@ spec:
           value: apps.region.example.com
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/applications.yaml
@@ -992,6 +1005,8 @@ spec:
 }
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/applications.yaml
@@ -1056,6 +1071,8 @@ spec:
           value: "1.10.3-ubi"
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/argocd.yaml

--- a/tests/common-clustergroup-medical-diagnosis-hub.expected.yaml
+++ b/tests/common-clustergroup-medical-diagnosis-hub.expected.yaml
@@ -288,6 +288,7 @@ data:
       localClusterDomain: apps.region.example.com
       namespace: pattern-namespace
       options:
+        applicationRetryLimit: 20
         installPlanApproval: Automatic
         syncPolicy: Automatic
         useCSV: false
@@ -644,6 +645,8 @@ spec:
           value: apps.region.example.com
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/applications.yaml
@@ -690,6 +693,8 @@ spec:
           value: apps.region.example.com
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/applications.yaml
@@ -736,6 +741,8 @@ spec:
           value: apps.region.example.com
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/applications.yaml
@@ -782,6 +789,8 @@ spec:
           value: apps.region.example.com
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/applications.yaml
@@ -828,6 +837,8 @@ spec:
           value: apps.region.example.com
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/applications.yaml
@@ -874,6 +885,8 @@ spec:
           value: apps.region.example.com
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/applications.yaml
@@ -920,6 +933,8 @@ spec:
           value: apps.region.example.com
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/applications.yaml
@@ -984,6 +999,8 @@ spec:
           value: "1.10.3-ubi"
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/applications.yaml
@@ -1030,6 +1047,8 @@ spec:
           value: apps.region.example.com
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/applications.yaml
@@ -1076,6 +1095,8 @@ spec:
           value: apps.region.example.com
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/applications.yaml
@@ -1131,6 +1152,8 @@ spec:
 ]
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/applications.yaml
@@ -1186,6 +1209,8 @@ spec:
 ]
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/applications.yaml
@@ -1232,6 +1257,8 @@ spec:
           value: apps.region.example.com
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/argocd.yaml

--- a/tests/common-clustergroup-naked.expected.yaml
+++ b/tests/common-clustergroup-naked.expected.yaml
@@ -66,6 +66,7 @@ data:
     enabled: all
     global:
       options:
+        applicationRetryLimit: 20
         installPlanApproval: Automatic
         syncPolicy: Automatic
         useCSV: true

--- a/tests/common-clustergroup-normal.expected.yaml
+++ b/tests/common-clustergroup-normal.expected.yaml
@@ -193,6 +193,7 @@ data:
       multiClusterTarget: all
       namespace: pattern-namespace
       options:
+        applicationRetryLimit: 20
         installPlanApproval: Automatic
         syncPolicy: Automatic
         useCSV: false
@@ -558,6 +559,8 @@ spec:
 ]
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/applications.yaml
@@ -604,6 +607,8 @@ spec:
           value: apps.region.example.com
   syncPolicy:
     automated: {}
+    retry:
+      limit: 20
     #  selfHeal: true
 ---
 # Source: pattern-clustergroup/templates/plumbing/hosted-sites.yaml

--- a/values-Nutanix.yaml
+++ b/values-Nutanix.yaml
@@ -1,0 +1,2 @@
+vmoperator:
+  pc: crimson-pc.dachlab.net

--- a/values-global.yaml
+++ b/values-global.yaml
@@ -9,6 +9,3 @@ global:
 
 main:
   clusterGroupName: hub
-
-vmoperator:
-  pc: crimson-pc.dachlab.net

--- a/values-group-one.yaml
+++ b/values-group-one.yaml
@@ -14,7 +14,6 @@ clusterGroup:
     - golang-external-secrets
 
   subscriptions:
-  
 
   projects:
     - eso


### PR DESCRIPTION
* Add more logic to `install` target

So this commit aims to tweak the `install` make target so that it can be invoked whenever we need to tweak things like git branch or git repo via CLI but the VP pattern has been installed via the OperatorHub. Currently if you just run `make install` from the repo after the operator has been installed via the Web UI, there will be an error like:
```
Error: rendered manifests contain a resource that already exists. Unable
to continue with install: Pattern "multicloud-gitops" in namespace
"openshift-operators" exists and cannot be imported into the current
release: invalid ownership metadata; label validation error: missing key
"app.kubernetes.io/managed-by": must be set to "Helm"; annotation
validation error: missing key "meta.helm.sh/release-name": must be set
to "multicloud-gitops"; annotation validation error: missing key
"meta.helm.sh/release-namespace": must be set to "default"
```

The problem is that the pattern object and the patterns operator subscription are missing some annotations and labels and that confuses helm install later on as it sees the object it needs to create but craps itself as it has no knowledge of it.

A few approaches were investigated to solve this:
1. Tweak the operator to add annotations. This, besides being a bit fragile and convoluted, is not a viable path, because the operator would also have to tweak the subscription that was used to install itself, which seems grossly out of bounds.
2. Tweak `make install` to always use `helm template` and pipe it through `oc apply`. This quickly would become rather complex and fragile because of the way CRDs are managed in helm: we would have to first install the CRD, wait for its successful creation and only then do another `helm template ... | oc apply -f-`. This quickly becomes rather involved and fragile. Also it is really reimplementing all of the `helm install` logic.
3. Add a post-renderer script to strip the standard helm annotations (https://helm.sh/docs/chart_best_practices/labels/#standard-labels). Seemingly helm does not pass those annotations to the post renderer but adds them afterwards, because a --post-renderer pointing to a script that does `yq e 'del(.metadata.annotations)'` did not work

Given the above limits, I decided to tweak `make install` so that if the CRD for the pattern is missing, it would just run the usual helm install. If the CRD is present then either it has been installed via the operator's UI or via `make install`. Either way, we just just run helm template and pipe it to oc apply, so that we won't force the helm standard annotations.

We have two invocations of helm template (one piped to oc apply set-last-applied) so we avoid the following warning during the first reapply call:

    Warning: resource patterns/multicloud-gitops is missing the
    kubectl.kubernetes.io/last-applied-configuration annotation which is
    required by oc apply. oc apply should only b e used on resources created
    declaratively by either oc create --save-config or oc apply. The missing
    annotation will be patched automatically.
    pattern.gitops.hybrid-cloud-patterns.io/multicloud-gitops configured
    Warning: resource subscriptions/patterns-operator is missing the
    kubectl.kubernetes.io/last-applied-configuration annotation which is
    required by oc apply. oc apply should o nly be used on resources created
    declaratively by either oc create --save-config or oc apply. The missing
    annotation will be patched automatically.
    subscription.operators.coreos.com/patterns-operator configured

Tested by installing a pattern via UI of the VP Operator, then locally ran `make install` and observed the new git branch being applied in the operator:

    Reapplying helm chart:
    pattern.gitops.hybrid-cloud-patterns.io/multicloud-gitops configured
    subscription.operators.coreos.com/patterns-operator configured
    pattern.gitops.hybrid-cloud-patterns.io/multicloud-gitops configured
    subscription.operators.coreos.com/patterns-operator configured
    make[1]: Leaving directory '/home/michele/Engineering/cloud-patterns/multicloud-gitops'

Tested also with a clean `make install` from scratch:

    Running helm:
    Release "multicloud-gitops" does not exist. Installing it now.
    NAME: multicloud-gitops
    LAST DEPLOYED: Wed Mar 15 12:14:49 2023
    NAMESPACE: default
    STATUS: deployed
    REVISION: 1
    TEST SUITE: None

* Fix .git missing warnings when running super-linter locally

See https://github.com/github/super-linter/issues/3786#issuecomment-1444923003

* Switch to ansible-automation-platform-23/ee-supported-rhel8:latest image by default

We want to stay up-to-date as to what image containing ansible we use. https://catalog.redhat.com/software/containers/ansible-automation-platform-23/ee-supported-rhel8/62c7060bc1d77e67d5893a78

This image contains ansible 2.14.3 and kubernetes.cor 2.3.2:

    $ podman run -it --rm --net=host --entrypoint /bin/bash registry.redhat.io/ansible-automation-platform-23/ee-supported-rhel8:latest -c "ansible-galaxy collection list|grep kubern"
    kubernetes.core         2.3.2

Tested on an MCG deployment

* Switch to ESO 0.8.2

Tested on MCG hub + spoke and everything worked correctly on both clusters.

* Fix up common/ tests

* Updated namespaces template to include labels and annotations functionality

* Added schema validation to support additional formal for labels and annotations

* Updated the values-example.yaml to include new format for namespaces

* Updated Changes.md to include new namespaces functionality.

* Updating CI tests

* Fixed Markdown errors

* Fix name of regional clusters to group-one

Via 8f5d2eaa94171a82ee6ddb5a918aa753265909b0 we switched to functional grouping as opposed to regional. Let's move the name to group-one as well. This is needed because otherwise on the remote cluster we have two different behaviours:
1. When referenced in ACM it will be the name that is set in values-hub.yaml inside the managedClusterGroup
2. When referenced in gitops it will be the name set in values-group-one.yaml

So they need to be the same or odd discrepancies will arise.

* Link to the new dashboard

* Formatting

* Drop dollar sign from default password policy

Sometimes they cause issues with some usage in patterns. Let's just drop them from the default policy.

* Make sure clusters always has an empty default

Otherwise we could get temporary errors which is unwanted.

* Do not validate certs when we use letsencrypt on the endpoints

Due to https://issues.redhat.com/browse/ACM-4398 we cannot leave validate_certs always on. Since we do not want to always disable it as that would be a security regression, we simply disable it only when the helm variable "letsencrypt.api_endpoint" is set to true. In that case we know that we are going to use letsencrypt certificates so it is okay to disable the verification until then. Once/if the ACM bug above gets fixed we can drop this.

Tested on MCG

* Add an experimental letsencypt chart

This change adds an experimental letsencrypt chart that allows a pattern user/developer to have all routes and the API endpoint use signed certificates by letsencrypt.

At this stage only AWS is supported. The full documentation is contained in the chart's README.md file

* Do not run kubeconform on the certificate stuff just yet

* Update the gitops patterns CRD

* Switch to gitops-1.8 channel in common

* Fix up common/ tests

* Add a change entry for gitops-1.8

* Do not apply the ocp-gitops-policy on the hub via ACM

The subscription for the gitops policy is controlled by the operator. If a user changes the gitops subscription channel via the operator, ACM will actually override this and push its own channel.

Tested via MCG:
* Before the fix
1. Installed the hub via the UI and chose "stable" as the gitops channel
2. Observed that once ACM started applying policies the gitops subscription was "upgraded" to gitops-1.8

* After the fix
1. Installed the hub via the UI and chose "stable" as the gitops channel
2. Observed that once ACM started applying policies the gitops subscription stayed the same on the hub

* Do not hardcode the gitops version that gets installed on spokes

Let's derive it from main.gitops.channel just like we do in other places.

Tested on an MCG hub/spoke setup and set the following values:

    main:
      gitops:
        channel: "gitops-1.7"

Correctly observed gitops-1.7 installed on both hub and cluster

* Fix up common/ tests

* Fix up kustomize example

In the same vein as Industrial Edge 57f41dc135f72011d3796fe42d9cbf05d2b82052 we call kustomize build.

Newer gitops versions dropped the openshift-clients rpm by default which contained kubectl. Let's just invoke "kustomize" directly as the binary is present in both old and new gitops versions

Since "kubectl kustomize" builds the set of resources by default, we need to switch to "kubectl build" by default

We also use the same naming conventions used in Industrial Edge while we're at it.

* Upgrade vault-helm to v0.24.0

Tested on MCG with hub and spoke

* Fix up common/ tests

* Add a hello-world ansible playbook example

Just a simple example that reads a helm value and puts it in a configmap

* Inject ANSIBLE_CONFIG in make ansible-lint

* Use new ansible-lint action

* Fix some ansible-lint warnings

* Fix up python versions

* Skip cannot find role error

Avoid checking those two playbooks the action seems to be too limited to understand where the ansible.cfg is

* Update ansible-lint action

* Update python version for workflows

* Fix new ansible-lint warnings

* Drop unused ansible playbooks

They are not used and were really examples more than anything else. Let's try and keep this codebase tidier and let's remove them.

* Switch to a hello world imperative example

This still demonstrates the imperative framework with a simple example

* Add hello world imperative example on group-one spokes as well

* Added health check for pvc resource in argocd.yaml

This allows argo to continue rolling out the rest of the applications. Without the health check the application is stuck in a progressing state and will not continue thus preventing any downstream application from deploying.

* adding tests

* Update super-linter image to latest

* Update super-linter image to latest

* Update CI workflows

* Update CI linters

- checkout v3
- ansible-lint v6
- superlinter v5

* updated template with why implemented comment

* Add dependabot settings for github actions

* Add dependabot settings for github actions

* Bump actions/setup-python from 1 to 4

Bumps [actions/setup-python](https://github.com/actions/setup-python) from 1 to 4.
- [Release notes](https://github.com/actions/setup-python/releases)
- [Commits](https://github.com/actions/setup-python/compare/v1...v4)

---
updated-dependencies:
- dependency-name: actions/setup-python dependency-type: direct:production update-type: version-update:semver-major ...



* adding tests

* Add commented out letsencrypt support in MCG

Adding it in ./values-AWS.yaml as this is the only supported cloud atm Put in a few comments linking the README and the chart's status

Tested on MCG hub and spoke and correctly got signed certs for all apps on hub and spoke.

* - Added functionality to support the following format for labels and annotations: labels: openshift.io/node-selector: "" annotations: openshift.io/cluster-monitoring: "true"

* Fixed CI Issues

* Applying @claudiol recommendation

* make test

* Avoid exited containers proliferation

When running the `pattern.sh` script multiple times, a lot of podman exited containers will be left on the machine, adding `--rm` parameter to `podman run` makes podman automatically delete the exited containers leaving the machine cleaner.

* Handling of pre-release builds is too complex for a helm chart

Generating the ICSP and allowing insecure registries is best done prior to helm upgrade, and requires VPN access to registry-proxy.engineering.redhat.com

* Fixing issues with operator groups

* Adding CI test

* Updated operator group template

* Updating CI issues

* Removed duplicate code for operatorgroup by using multiple conditions

* Switch to ACM 2.7 channel

According to https://access.redhat.com/labs/ocpouic/?operator=advanc&&ocp_versions=4.10,4.11,4.12 the channel exists in 4.10, 4.11 and 4.12

Tested on OCP 4.13 (pre-release) and 4.10

* Add new tests after common rebase

* Allow overriding the pattern's name

This is especially useful when multiple people are working on a pattern an have been using different names:

    $ make help |grep Pattern:
    Pattern: multicloud-gitops
    $ make NAME=foobar help |grep Pattern:
    Pattern: foobar

* Fix up common/ tests

* Add precise instruction to upgrade the vault subchart

* Upgrade vault-helm to v0.24.1

* Add an item to README.md

* Fix up common/ tests

* Fix super linter

* Fix up common/ tests

* Set gitOpsSpec.operatorSource

After merging https://github.com/hybrid-cloud-patterns/patterns-operator/commit/235b303fbbe1efdbbacf7d32862f477cf3796c4c it is now effectively possible to pick a different catalogSource for the gitops operator. This is needed in order to allow CI to install the gitops operator from an IIB

* Introduce EXTRA_HELM_OPTS

This variable can be set in order to pass additional helm arguments from the the command line. I.e. we can set things without having to tweak values files So it is now possible to run something like the following:

  ./pattern.sh make install \
  EXTRA_HELM_OPTS="--set main.gitops.operatorSource=iib-49232"

* Disable var-naming[no-role-prefix] in ansible lint

* Add new ansible role to deal with IIBs

* Simplify load-iib target

* Add templates folder

* Fix a couple of linting warnings

* Fix some super-linter complaints

* Skip the iib-ci playbook

* Drop var-naming[no-role-prefix] linter

* Allow for multiple images when calling load-iib

* Add help for load-iib

* Output index_image in make

* Output index_image in make (2)

* Set facts later in the playbook not in defaults/

* Fix how we export vars in make load-iib

* Fix how we export vars in make load-iib (2)

* Use machineCount to register the number of nodes that need to be ready

* Add helpful debug messages

* Add | on shell now that we call pipefail

* Test dropping nevercontact source

* Skip insecure tls when logging in

* Also allow gchr.io

* Revert "Test dropping nevercontact source"

This reverts commit d8746a37fce2663018f52203c892f00b825e32a7.

* Fix typo

* Clarify instructions in the README file

* Automate the channel example

* Find out KUBEADMINAPI programmatically

* Use command instead of shell

* Do not grep for operator bundle unless it is the gitops operator

* Also whitelist ghcr.io

* Fetch the operator bundle itself in a more robust way

It seems that the operator bundle image itself is nowhere to be found inside any OCP cluster object (it's not in packagemanifests nor catalogsource). Resorting to parsing the IIB via opm alpha commands to fetch the exact image.

* Add more mirrors

* Some more work to support MCE

* Cleanup spacing

* Fix super-linter

* Move task in right folder

* Drop last mention of operator instead of item

* Fix up common/ tests

* Drop ansible-lint on common for now

* Improve the grepping for the operator bundle

Without also grepping for the default_channel we can end up getting multiple results, which breaks everything.

Tested this and it fixed the issue I was seeing with the openshift-gitops-operator this morning

* Drop display_skipped_hosts

display_skipped_hosts=False has a horrible side-effect: When a task takes a long time, it is always the *next* task and not the one printed on the screen/log. That is because ansible has to wait for the task to finish before printing it as it does not know before hand if the host will be skipped and hence the task should not be displayed at all

* Drop display_skipped_hosts

* Be more specific about the steps in the README

* Upgrade ESO to v0.8.2

* Update README.md

* Update tests after eso 0.8.2 upgrade

* Move to new spec format for dex/sso

Via https://issues.redhat.com/browse/GITOPS-2761 we are told that the dex configuration has a new format.
Old format:

    spec:
      dex:
        openShiftOAuth: true
        resources:
        ...

New format:

    spec:
      sso:
        provider: dex
        dex:
          openShiftOAuth: true
          resources:
          ...

This format is only supported starting with gitops-1.8.0, so we should merge this only when we are absolutely sure that no pattern in no situation needs an older gitops version.

Tested on MCG with gitops-1.8.2

Note: with this change gitops < 1.8 is not supported. Starting with gitops-1.9 the old format will be unsupported.

* Disable ArgoCD from kubeconform

The reason is that most of the tools we used to generate the json schema, seem to be unmaintained, so it is getting hard to update our schemas in our GH org. We'll need to revisit this in the future.

* Fix up tests after common rebase

* Add a short line about username/token for the iib role on OCP <= 4.12

* Drop https:// from podman login

Seems we hit https://www.github.com/containers/podman/issues/13691 at least with older podman versions.

If this turns out to break podman 4.5.0 I will special case it later

* Set the mce-subscription-spec annotation

We set it by default to "redhat-operators" and if defined to .Values.clusterGroup.subscriptions.acm.source The reason we do this is the following:
1. In a default deployment scenario MCE has to be deployed as normal from the redhat-operators catalogSource just as ACM is
2. When we deploy gitops-operator from an IIB instead, MCE would be installed trying to get it from the IIB because https://www.github.com/stolostron/multiclusterhub-operator/pull/975 made it so that it picks the latest version looking at all catalog sources. But since we only mirrored the gitops operator in the cluster, this breaks as the images for MCE from the IIB are not there By setting the default to "redhat-operators" we fix this case
3. Now in the case where we want to install ACM from an IIB we need to be able to override this and we will pick whatever value is set in .Values.clusterGroup.subscriptions.acm.source, which will need to be defined for this to work when testing ACM+MCE from an IIB

Note: Currently point 3. works only if you set it in a values file. Setting .Values.clusterGroup.subscriptions.acm.source via extraParams won't be passed down from the clusterGroup app to the applications. It's a bug that we need to fix.

Note(2): We surround this with an 'if kindIs "map" .Values.clusterGroup.subscriptions' because we do not want to break things if subscription is a list and not a map. If we ever manage to drop subscriptions as list, then we can remove that if

* Fix up tests after common rebase

* Fix typo in README for iib

* Simplify the README a bit

* Add support for extraParams being passed down to all applications

Via https://github.com/hybrid-cloud-patterns/patterns-operator/pull/74 we add the extraParams in an extraParametersNested dictionary that holds the extraParams key/value pairs. If they exist, let's add them as parameters.

This allows them to end up in the applications.

* Add a lookup playbook to figure out IIB numbers

* Allow overriding channel and source when installing the patterns-operator

This will allow us to test the patterns-operator using a different catalogsource (potentially installed via an IIB). So we can run:

make EXTRA_HELM_OPTS="\
  --set main.extraParameters[0].name=main.patternsOperator.channel --set main.extraParameters[0].value=slow \
  --set main.extraParameters[1].name=main.patternsOperator.source --set main.extraParameters[1].value=patten-index" install

* Add a link describing the secret format

* Fix small typo in iib instructions

* Drop a redirect and up retries when pushing the IIB to the internal registry

* Update ESO to v0.8.3

* Fix up common/ tests

* WIP add presync for eso that waits for vault to be up

* Add tests

* Fix image and comment

* Adding rbac to support the vault sa checking on the vault-0 pod status.

* Make Test

* Removed previous version of common to convert to subtree from https://github.com/hybrid-cloud-patterns/common.git main

* Make test

* Revert "Make Test"

This reverts commit 64e9dc7a3ed3fcdd358cfbcb4d8c62121fc2365b.

* Revert "Adding rbac to support the vault sa checking on the vault-0 pod status."

This reverts commit 598bc74fefd2cb72fe90834989206ad12b130a69.

* Revert "Fix image and comment"

This reverts commit d4d3fe100681dd858601ed1934f0244333ddea49.

* Revert "Add tests"

This reverts commit ab5532a7e602235bd2ec02a7c9dff78f82309856.

* Revert "WIP add presync for eso that waits for vault to be up"

This reverts commit 279769915f94202dcaa7734ac0d07a23e70da8b5.

* Increase the default retry limit when syncing

ArgoCD will retry 5 times by default to sync an application in case of errors and then will give up. So if an application contains a reference to a CRD that has not been installed yet (say because it will be installed by another application), it will error out and retry later. This happens by default for a maximum of 5 times [1]. After those 5 times the application will give up and will stay in Degraded moded and eventually move to Failed. In this case a manual sync will usually fix the application just fine (i.e. as long as the missing CRD has been installed in the meantime).

Now to solve this issue we can add complex preSync Jobs that wait for the needed resources, but this fundamentally breaks the simplicity of things and introduces unneeded dependencies. In this change we just increase the default retry limit to something larger (20) that should cover most cases. The retry limit functionality is rather undocumented currently in the docs but is defined at [2] and also shown at [3].

In our patterns' case the concrete issue happened as follows:
1. ESO ClusterSecrets were often not synced/degraded
2. We introduced a Job in a preSync hook for the ESO chart that would wait on vault to be ready before applying the rest of ESO
3. MCG started failing because the config-demo app had already tried to sync 5 times and failed everytime because the ESO CRDs were not installed yet (due to ESO waiting on vault)

So instead of adding yet another job, let's just try a lot more often. We picked 20 as a sane default because that should have argo try for about 60 minutes (3min is the default maximum backoff limit)

Tested with two MCG installations (with the ESO Job hook included) and both worked out of the box. Whereas before I managed to get three failures out of three installs.

[1] https://github.com/argoproj/argo-cd/blob/master/controller/appcontroller.go#L1680
[2] https://github.com/argoproj/argo-cd/blob/master/manifests/crds/application-crd.yaml#L1476
[3] https://github.com/argoproj/argo-cd/blob/master/docs/operator-manual/application.yaml#L202C18-L202C100

* Add Changes.md entry

* Fix up tests after common rebase

* introduce nutanix values

---------